### PR TITLE
vendor project fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ macro(build_yaml_cpp)
   endif()
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    if(QNX)
+      set_qnx_external_project_options()
+    endif()
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
   endif()
 


### PR DESCRIPTION
Fixes #12
 
When cross compiling for QNX a toolchain file is provided to COLCON in addition to other command line arguments that are related to the architecture being built. Using cmake's externalproject_add() function, the value of the variables set from command line, outside the toolchain file, have to be re-set for the external project by setting them again and including them in the extra_cmake_args variable. The macro set_qnx_external_project_options() implements this functionality. This macro is available in the toolchain file.