### PR TITLE
Avoid registering the package in the cmake registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ macro(build_yaml_cpp)
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yaml_cpp_install
       ${extra_cmake_args}
+      -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON
       -Wno-dev
   )
 
@@ -68,7 +69,7 @@ endmacro()
 # NO_CMAKE_PACKAGE_REGISTRY used to avoid finding the library downloaded in WORKSPACE B
 # when building workspace A.
 # This should only find a system installed yaml-cpp and thus the environment hook isn't needed.
-find_package(yaml-cpp 0.6 QUIET NO_CMAKE_PACKAGE_REGISTRY)
+find_package(yaml-cpp 0.6 QUIET)
 if(NOT yaml-cpp_FOUND)
   build_yaml_cpp()
 


### PR DESCRIPTION
This avoids registering yaml-cpp in the cmake package registry, instead of restricting `find_pkg`.
See https://cmake.org/cmake/help/v3.2/variable/CMAKE_EXPORT_NO_PACKAGE_REGISTRY.html#variable:CMAKE_EXPORT_NO_PACKAGE_REGISTRY.

Note: This may make CI fail, e.g.: macOS builds aren't containerized. We will need to prune the ~/.cmake folder first.

We could maybe have an ament function that collects the usual cmake arguments that we want to pass along to external projects:
- DCMAKE_EXPORT_NO_PACKAGE_REGISTRY
- DCMAKE_C_COMPILER, DCMAKE_C_FLAGS, DCMAKE_CXX_COMPILER, DCMAKE_CXX_FLAGS
- [android things](https://github.com/ros2/spdlog_vendor/blob/0223d4586fff5863e6d380c38bde5fee46802af7/CMakeLists.txt#L20-L44)

We likely want to forward those flags to every external project, and repeating them everywhere is error prone.