### PR TITLE
7.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package yaml_cpp_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+7.1.1 (2021-12-07)
+------------------
+* Update maintainers to Audrow Nash (`#26 <https://github.com/ros2/yaml_cpp_vendor/issues/26>`_)
+* Fix handling of CMAKE_C[XX]_FLAGS lists (`#24 <https://github.com/ros2/yaml_cpp_vendor/issues/24>`_)
+* Contributors: Christophe Bedard, Scott K Logan
+
 7.1.0 (2021-03-18)
 ------------------
 * Always preserve source permissions in vendor packages (`#22 <https://github.com/ros2/yaml_cpp_vendor/issues/22>`_)

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>yaml_cpp_vendor</name>
-  <version>7.1.0</version>
+  <version>7.1.1</version>
   <description>
     Wrapper around yaml-cpp, it provides a fixed CMake module and an ExternalProject build of it.
   </description>


### PR DESCRIPTION
Current version in Galactic and Rolling is 7.1.0.

Normally, we'd bump the minor so that we have room for maintenance releases in previous distros, but because both of the changes being released here should be released in Galactic anyway, it's a lot simpler to just fast-forward Galactic to be even with `master` and release both at `7.1.1`.

I can take care of that, pending maintainer approval of this PR.