### PR TITLE
Export YAML_CPP_DLL define on Windows

### DIFF
--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -16,3 +16,6 @@ set(yaml_cpp_vendor_LIBRARIES ${YAML_CPP_LIBRARIES})
 set(yaml_cpp_vendor_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
 
 list(APPEND yaml_cpp_vendor_TARGETS yaml-cpp)
+if(WIN32)
+  set_target_properties(${YAML_CPP_LIBRARIES} PROPERTIES INTERFACE_COMPILE_DEFINITIONS YAML_CPP_DLL)
+endif()


### PR DESCRIPTION
This will fix #10.

I saw that #25 will also fix #10. I agree that is the better long term solution and this can be reverted once that is merged. However, until the CI issues in the PR are fixed, I think this is the best alternative.