### PR TITLE
Add missing dependency on yaml-cpp

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>yaml-cpp</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This vendor package is configured to use the system package if it is present, and fall back to building the package from source.

Without a dependency on the system package, rosdep won't install it, and we'll always be building from source.

Here's the rosdep key:
https://github.com/ros/rosdistro/blob/de14ca764acc562ab9e79a5b5c90ed322f82460e/rosdep/base.yaml#L8007-L8020

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16557)](http://ci.ros2.org/job/ci_linux/16557/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11144)](http://ci.ros2.org/job/ci_linux-aarch64/11144/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16936)](http://ci.ros2.org/job/ci_windows/16936/)