### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ option(FORCE_BUILD_VENDOR_PKG
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
-set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-cmake_policy(SET CMP0135 NEW)
-
 macro(build_yaml_cpp)
   set(extra_cmake_args)
 
@@ -40,6 +37,10 @@ macro(build_yaml_cpp)
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+  endif()
+
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+	cmake_policy(SET CMP0135 NEW)
   endif()
 
   include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ macro(build_yaml_cpp)
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
-    DOWNLOAD_EXTRACT_TIMESTAMP true
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yaml_cpp_install
       ${extra_cmake_args}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(FORCE_BUILD_VENDOR_PKG
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
-cmake_policy(SET CMP0135 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
 
 macro(build_yaml_cpp)
   set(extra_cmake_args)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ option(FORCE_BUILD_VENDOR_PKG
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 macro(build_yaml_cpp)
   set(extra_cmake_args)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ macro(build_yaml_cpp)
   ExternalProject_Add(yaml_cpp-0.7.0
     URL https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz
     URL_MD5 74d646a3cc1b5d519829441db96744f0
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
 set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+cmake_policy(SET CMP0135 NEW)
 
 macro(build_yaml_cpp)
   set(extra_cmake_args)
@@ -48,7 +49,7 @@ macro(build_yaml_cpp)
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
-    DOWNLOAD_EXTRACT_TIMESTAMP false
+    DOWNLOAD_EXTRACT_TIMESTAMP true
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yaml_cpp_install
       ${extra_cmake_args}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ option(FORCE_BUILD_VENDOR_PKG
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
+cmake_policy(SET CMP0135 NEW)
+
 macro(build_yaml_cpp)
   set(extra_cmake_args)
 
@@ -46,6 +48,7 @@ macro(build_yaml_cpp)
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
+    DOWNLOAD_EXTRACT_TIMESTAMP false
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yaml_cpp_install
       ${extra_cmake_args}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ option(FORCE_BUILD_VENDOR_PKG
   "Build yaml-cpp from source, even if system-installed package is available"
   OFF)
 
-cmake_policy(SET CMP0135 NEW)
-
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
@@ -45,6 +43,7 @@ macro(build_yaml_cpp)
   ExternalProject_Add(yaml_cpp-0.7.0
     URL https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz
     URL_MD5 74d646a3cc1b5d519829441db96744f0
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,6 @@ macro(build_yaml_cpp)
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
   endif()
 
-  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-	cmake_policy(SET CMP0135 NEW)
-  endif()
-
   include(ExternalProject)
   ExternalProject_Add(yaml_cpp-0.7.0
     URL https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.7.0.tar.gz
@@ -64,6 +60,8 @@ macro(build_yaml_cpp)
       ${CMAKE_INSTALL_PREFIX}/opt/yaml_cpp_vendor
     USE_SOURCE_PERMISSIONS
   )
+
+  cmake_policy(SET CMP0135 NEW)
 endmacro()
 
 # NO_CMAKE_PACKAGE_REGISTRY used to avoid finding the library downloaded in WORKSPACE B

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option(FORCE_BUILD_VENDOR_PKG
   "Build yaml-cpp from source, even if system-installed package is available"
   OFF)
 
+cmake_policy(SET CMP0135 NEW)
+
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
@@ -60,8 +62,6 @@ macro(build_yaml_cpp)
       ${CMAKE_INSTALL_PREFIX}/opt/yaml_cpp_vendor
     USE_SOURCE_PERMISSIONS
   )
-
-  cmake_policy(SET CMP0135 NEW)
 endmacro()
 
 # NO_CMAKE_PACKAGE_REGISTRY used to avoid finding the library downloaded in WORKSPACE B

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ macro(build_yaml_cpp)
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/yaml_cpp_install
       ${extra_cmake_args}

--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -1,9 +1,5 @@
 find_package(yaml-cpp QUIET)
 
-if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
-endif()
-
 if(NOT yaml-cpp_FOUND)
   # add the local Modules directory to the modules path
   if(WIN32)

--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -1,6 +1,5 @@
 find_package(yaml-cpp QUIET)
 
-# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
   cmake_policy(SET CMP0135 OLD)
 endif()

--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -1,5 +1,10 @@
 find_package(yaml-cpp QUIET)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 if(NOT yaml-cpp_FOUND)
   # add the local Modules directory to the modules path
   if(WIN32)


### PR DESCRIPTION
Warning fix
Signed-off-by: Cristóbal Arroyo [cristobal.arroyo@ekumenlabs.com](mailto:cristobal.arroyo@ekumenlabs.com)

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new machines ([windows-container-bd99e2f0](https://ci.ros2.org/computer/windows-container-bd99e2f0/) and others). It’s caused by a new CMake version (3.24) that expects this policy to be set.

Solution with this PR changes:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17246)](http://ci.ros2.org/job/ci_linux/17246/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11787)](http://ci.ros2.org/job/ci_linux-aarch64/11787/)
* Windows [![Build Status](https://ci.ros2.org/job/ci_windows/17709/badge/icon)](https://ci.ros2.org/job/ci_windows/17709/)
> This last windows build wasn't run right (probably the agent didn't had the CMake3.24 version)


