### PR TITLE
Sets CMP0135 policy behavior to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ ament_add_default_options()
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 macro(build_yaml_cpp)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

[This comment](https://github.com/ros2/rosbag2/pull/1084#pullrequestreview-1103004078) suggest changing the behavior from OLD to NEW. This PR does that for this package.

Ci_launch_test:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17268)](http://ci.ros2.org/job/ci_linux/17268/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11809)](http://ci.ros2.org/job/ci_linux-aarch64/11809/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17749)](http://ci.ros2.org/job/ci_windows/17749/)