### PR TITLE
Revert "Export YAML_CPP_DLL define on Windows (#30)"

### DIFF
--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -18,6 +18,3 @@ set(yaml_cpp_vendor_LIBRARIES ${YAML_CPP_LIBRARIES})
 set(yaml_cpp_vendor_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
 
 list(APPEND yaml_cpp_vendor_TARGETS yaml-cpp)
-if(WIN32)
-  set_target_properties(${YAML_CPP_LIBRARIES} PROPERTIES INTERFACE_COMPILE_DEFINITIONS YAML_CPP_DLL)
-endif()


### PR DESCRIPTION
This reverts commit efe53716ce031354769116ad359ea3d0f1c3771a.

The change is causing MSBuild warnings, so I'm hesitant to release this change into Foxy. If we want to consider it, we should at the very least resolve the warnings coming from core packages (see https://github.com/ros2/yaml_cpp_vendor/pull/31#issuecomment-1046064334).

FYI @Ace314159 