### PR TITLE
Revamp the extras file to find the correct version.

### DIFF
--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -1,16 +1,12 @@
-find_package(yaml-cpp QUIET)
-
-if(NOT yaml-cpp_FOUND)
-  # add the local Modules directory to the modules path
-  if(WIN32)
-    set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/CMake")
-  else()
-    set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/share/cmake/yaml-cpp")
-  endif()
-  message(STATUS "Setting yaml-cpp_DIR to: '${yaml-cpp_DIR}'")
-
-  find_package(yaml-cpp CONFIG REQUIRED QUIET)
+# add the local Modules directory to the modules path
+if(WIN32)
+  set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/CMake")
+else()
+  set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/share/cmake/yaml-cpp")
 endif()
+message(STATUS "Setting yaml-cpp_DIR to: '${yaml-cpp_DIR}'")
+
+find_package(yaml-cpp REQUIRED)
 
 set(yaml_cpp_vendor_LIBRARIES ${YAML_CPP_LIBRARIES})
 set(yaml_cpp_vendor_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})


### PR DESCRIPTION
The current yaml_cpp_vendor-extras.cmake file first attempts to find the yaml-cpp package, and only if that fails goes ahead and adds the vendored package to the path.

But that means that currently, if we force build a vendor package, downstream packages will still find the system one if both are installed.  That isn't the desired behavior.

Revamp this file so that we unconditionally add in the location where the vendor package would be first, then try to find it.  If that location exists, and has the vendored package, we'll use that.  If that location does not exist, we'll still go searching in the normal OS directories for the package, which should find the system one (if it exists).

Thanks to @cottsay for the advice on fixing this one.  This should help to fix https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/ (though a couple of other fixes will be needed as well).