### PR TITLE
Disable the -Wshadow warning when building under clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ ament_vendor(yaml_cpp_vendor
   SATISFIED ${yaml-cpp_FOUND}
   VCS_URL https://github.com/jbeder/yaml-cpp.git
   VCS_VERSION yaml-cpp-0.7.0
+  PATCHES patches
   CMAKE_ARGS
     "-DCMAKE_CXX_FLAGS=${YAML_CPP_CXX_FLAGS}"
     -DYAML_CPP_BUILD_CONTRIB:BOOL=OFF

--- a/patches/0001-disable-shadow-warning.patch
+++ b/patches/0001-disable-shadow-warning.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2023-12-01 16:47:18.388383723 +0000
++++ b/CMakeLists.txt	2023-12-01 16:47:23.630353853 +0000
+@@ -93,7 +93,7 @@ endif()
+ 
+ target_compile_options(yaml-cpp
+   PRIVATE
+-    $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
++    $<${not-msvc}:-Wall -Wextra -Weffc++ -Wno-long-long>
+     $<${not-msvc}:-pedantic -pedantic-errors>
+ 
+     $<$<AND:${backport-msvc-runtime},${msvc-rt-mtd-static}>:-MTd>


### PR DESCRIPTION
There are a bunch of shadowed variables within yaml-cpp itself.  Disable the warnings we get when compiling under clang by removing the -Wshadow flag.

Before: Clang [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_clang_libcxx&build=44)](http://ci.ros2.org/job/ci_linux_clang_libcxx/44/)
After: Clang [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux_clang_libcxx&build=45)](http://ci.ros2.org/job/ci_linux_clang_libcxx/45/)