### PR TITLE
Support yaml-cpp >= 0.8.0

### DIFF
--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -11,10 +11,15 @@ find_package(yaml-cpp REQUIRED)
 set(yaml_cpp_vendor_LIBRARIES ${YAML_CPP_LIBRARIES})
 set(yaml_cpp_vendor_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
 
-list(APPEND yaml_cpp_vendor_TARGETS yaml-cpp)
-if(WIN32)
-  # On Windows, yaml-cpp 0.7.0 requires that downstream consumers set YAML_CPP_DLL and
-  # not yaml_cpp_EXPORT in order to set dllimport properly.
-  # This behavior will likely change in future versions of yaml-cpp.
-  set_target_properties(yaml-cpp PROPERTIES INTERFACE_COMPILE_DEFINITIONS YAML_CPP_DLL)
+# since yaml-cpp 0.8.0, yaml-cpp supports the yaml-cpp::yaml-cpp target
+if(TARGET yaml-cpp::yaml-cpp)
+  list(APPEND yaml_cpp_vendor_TARGETS yaml-cpp::yaml-cpp)
+else()
+  list(APPEND yaml_cpp_vendor_TARGETS yaml-cpp)
+  if(WIN32)
+    # On Windows, yaml-cpp 0.7.0 requires that downstream consumers set YAML_CPP_DLL and
+    # not yaml_cpp_EXPORT in order to set dllimport properly.
+    # This behavior will likely change in future versions of yaml-cpp.
+    set_target_properties(yaml-cpp PROPERTIES INTERFACE_COMPILE_DEFINITIONS YAML_CPP_DLL)
+  endif()
 endif()


### PR DESCRIPTION
Since yaml-cpp 0.8.0, the imported target of yaml-cpp is called `yaml-cpp::yaml-cpp`, not `yaml-cpp`. 

To handle this, in this PR I modified the logic that sets `yaml_cpp_vendor_TARGETS` to set it to `yaml-cpp::yaml-cpp` if it exists. Furthermore, I also use the presence of `yaml-cpp::yaml-cpp` as a proxy to detect if yaml-cpp >= 0.8.0 is used, and avoid the manual setting of `YAML_CPP_DLL` as it is not needed anymore. 

If `yaml-cpp::yaml-cpp` is not present (i.e. yaml-cpp <= 0.7.0), the logic remains exactly the one before this PR.

Related downstream comment: https://github.com/RoboStack/ros-humble/issues/136#issuecomment-1937034696 .