### PR TITLE
Removed warnigns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ ament_vendor(yaml_cpp_vendor
     -DYAML_CPP_BUILD_TESTS:BOOL=OFF
     -DYAML_CPP_BUILD_TOOLS:BOOL=OFF
     -DYAML_BUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+  PATCHES patches
 )
 
 ament_package(

--- a/patches/.gitattributes
+++ b/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf

--- a/patches/0001.patch
+++ b/patches/0001.patch
@@ -1,0 +1,46 @@
+diff --git a/src/emitterstate.h b/src/emitterstate.h
+index 8f379ca..d86c6c2 100644
+--- a/src/emitterstate.h
++++ b/src/emitterstate.h
+@@ -24,9 +24,16 @@ struct FmtScope {
+ struct GroupType {
+   enum value { NoType, Seq, Map };
+ };
++#if defined(__clang__)
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wshadow"
++#endif
+ struct FlowType {
+   enum value { NoType, Flow, Block };
+ };
++#if defined(__clang__)
++#pragma clang diagnostic pop
++#endif
+
+ class EmitterState {
+  public:
+diff --git a/src/emitterutils.h b/src/emitterutils.h
+index 3a7d598..360eb6d 100644
+--- a/src/emitterutils.h
++++ b/src/emitterutils.h
+@@ -20,6 +20,10 @@ class ostream_wrapper;
+ namespace YAML {
+ class Binary;
+
++#if defined(__clang__)
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wshadow"
++#endif
+ struct StringFormat {
+   enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
+ };
+@@ -27,6 +31,9 @@ struct StringFormat {
+ struct StringEscaping {
+   enum value { None, NonAscii, JSON };
+ };
++#if defined(__clang__)
++#pragma clang diagnostic pop
++#endif
+
+ namespace Utils {
+ StringFormat::value ComputeStringFormat(const std::string& str,

--- a/patches/0001.patch
+++ b/patches/0001.patch
@@ -1,46 +1,13 @@
-diff --git a/src/emitterstate.h b/src/emitterstate.h
-index 8f379ca..d86c6c2 100644
---- a/src/emitterstate.h
-+++ b/src/emitterstate.h
-@@ -24,9 +24,16 @@ struct FmtScope {
- struct GroupType {
-   enum value { NoType, Seq, Map };
- };
-+#if defined(__clang__)
-+#pragma clang diagnostic push
-+#pragma clang diagnostic ignored "-Wshadow"
-+#endif
- struct FlowType {
-   enum value { NoType, Flow, Block };
- };
-+#if defined(__clang__)
-+#pragma clang diagnostic pop
-+#endif
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72fa542..855fc69 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -111,7 +111,7 @@ endif()
+ if(YAML_CPP_MAIN_PROJECT)
+   target_compile_options(yaml-cpp
+     PRIVATE
+-      $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
++      $<${not-msvc}:-Wall -Wextra -Wno-shadow -Weffc++ -Wno-long-long>
+       $<${not-msvc}:-pedantic -pedantic-errors>)
+ endif()
 
- class EmitterState {
-  public:
-diff --git a/src/emitterutils.h b/src/emitterutils.h
-index 3a7d598..360eb6d 100644
---- a/src/emitterutils.h
-+++ b/src/emitterutils.h
-@@ -20,6 +20,10 @@ class ostream_wrapper;
- namespace YAML {
- class Binary;
-
-+#if defined(__clang__)
-+#pragma clang diagnostic push
-+#pragma clang diagnostic ignored "-Wshadow"
-+#endif
- struct StringFormat {
-   enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
- };
-@@ -27,6 +31,9 @@ struct StringFormat {
- struct StringEscaping {
-   enum value { None, NonAscii, JSON };
- };
-+#if defined(__clang__)
-+#pragma clang diagnostic pop
-+#endif
-
- namespace Utils {
- StringFormat::value ComputeStringFormat(const std::string& str,


### PR DESCRIPTION
There are som warnings when compiling with clang https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1868/clang-tidy/new/folder.-1318783583/

The PR should fix them