### PR TITLE
Fix yaml-cpp_DIR path in extras (lib/cmake for yaml-cpp 0.8.0)

### DIFF
--- a/yaml_cpp_vendor-extras.cmake.in
+++ b/yaml_cpp_vendor-extras.cmake.in
@@ -2,6 +2,6 @@
 if(WIN32)
   set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/CMake")
 else()
-  set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/share/cmake/yaml-cpp")
+  set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/yaml_cpp_vendor/lib/cmake/yaml-cpp")
 endif()
 message(STATUS "Setting yaml-cpp_DIR to: '${yaml-cpp_DIR}'")


### PR DESCRIPTION
## What
On this branch `yaml_cpp_vendor` builds **yaml-cpp 0.8.0**, which installs its CMake package config to `${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp` = `lib/cmake/yaml-cpp` (see yaml-cpp `CMakeLists.txt`). But `yaml_cpp_vendor-extras.cmake.in` points `yaml-cpp_DIR` at `share/cmake/yaml-cpp`. That plain `set()` shadows the correct value in the consumer scope, so downstream `find_package(yaml_cpp_vendor)` -> `find_package(yaml-cpp)` fails:

```
Could not find a package configuration file provided by "yaml-cpp"
...
ld: library 'yaml-cpp' not found
```

Consumers that `find_package(yaml-cpp)` directly (bypassing the extras) build fine — which is exactly the split we saw.

## Fix
Point the extras at `lib/cmake/yaml-cpp`, matching where yaml-cpp 0.8.0 actually installs its config.

## Tested on
- **macOS 26** (Apple Silicon / arm64) — GitHub Actions `macos-26` runners
- **Apple clang 21.0.0** (`clang-2100.1.1.101`, `arm64-apple-darwin25.5.0`), C++17
- yaml-cpp 0.8.0 built from source via `ament_vendor`, CMake 4.3
- Verified: yaml-cpp consumers (nebula_velodyne_common, autoware_test_utils, as2_core, …) build after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
